### PR TITLE
Switched from uninterpreted to defined functions for querying

### DIFF
--- a/role_analyzer.py
+++ b/role_analyzer.py
@@ -835,7 +835,7 @@ def labels_as_z3_map(
 
 def traits_as_z3_map(
     authz_context: AuthzContext,
-    concrete_traits: typing.Optional[dict[str, list[str]]],
+    concrete_traits: dict[str, list[str]],
     user_type: UserType,
 ):
     """
@@ -853,7 +853,7 @@ def traits_as_z3_map(
         [user_trait_key, user_trait_value],
         Case(
             user_trait_key,
-            [] if concrete_traits is None else list(concrete_traits.items()),
+            list(concrete_traits.items()),
             lambda traits: z3.Or(
                 [user_trait_value == z3.StringVal(trait) for trait in traits]
             ),
@@ -885,7 +885,8 @@ def role_allows_user_access_to_entity(
     Does not check whether the user actually possesses that role.
     """
     authz_context = AuthzContext(False)
-    traits_as_z3_map(authz_context, user_traits, user_type)
+    if user_traits is not None and user_type is not None:
+        traits_as_z3_map(authz_context, user_traits, user_type)
     labels_as_z3_map(authz_context, entity_labels, entity_type)
     allows_expr = allows(authz_context, role)
     logging.debug(allows_expr)

--- a/role_analyzer.py
+++ b/role_analyzer.py
@@ -878,7 +878,7 @@ def role_allows_user_access_to_entity(
     user_type: typing.Optional[UserType],
     entity_labels: dict[str, str],
     entity_type: EntityType,
-    solver: z3.Solver
+    solver: z3.Solver,
 ) -> bool:
     """
     Determines whether the given role provides the user access to the entity.
@@ -894,6 +894,6 @@ def role_allows_user_access_to_entity(
     result = solver.check()
     if z3.sat == result:
         logging.debug(solver.model())
-        return True;
+        return True
     else:
-        return False;
+        return False

--- a/role_analyzer.py
+++ b/role_analyzer.py
@@ -872,20 +872,27 @@ def traits_as_z3_map(
     )
 
 
-# Determines whether the given role provides the user access to the entity.
-# Does not check whether the user actually possesses that role.
 def role_allows_user_access_to_entity(
     role: typing.Any,
     user_traits: typing.Optional[dict[str, list[str]]],
-    user_type: UserType,
+    user_type: typing.Optional[UserType],
     entity_labels: dict[str, str],
     entity_type: EntityType,
-    solver: z3.Solver = z3.Solver(),
+    solver: z3.Solver
 ) -> bool:
+    """
+    Determines whether the given role provides the user access to the entity.
+    Does not check whether the user actually possesses that role.
+    """
     authz_context = AuthzContext(False)
     traits_as_z3_map(authz_context, user_traits, user_type)
     labels_as_z3_map(authz_context, entity_labels, entity_type)
     allows_expr = allows(authz_context, role)
-    # print(allows_expr)
+    logging.debug(allows_expr)
     solver.add(allows_expr)
-    return z3.sat == solver.check()
+    result = solver.check()
+    if z3.sat == result:
+        logging.debug(solver.model())
+        return True;
+    else:
+        return False;

--- a/role_analyzer.py
+++ b/role_analyzer.py
@@ -755,7 +755,7 @@ def labels_as_z3_map(
     z3.RecAddDefinition(
         authz_context.entities[entity_type].keys,
         [required_key],
-        z3.Bool(False) if concrete_labels is None else z3.Or([required_key == z3.StringVal(key) for key in concrete_labels.keys()])
+        z3.BoolVal(False) if concrete_labels is None else z3.Or([required_key == z3.StringVal(key) for key in concrete_labels.keys()])
     )
 
     # Add definition of required labels function.
@@ -777,7 +777,7 @@ def labels_as_z3_map(
         z3.RecAddDefinition(
             authz_context.entities[other_entity_type].keys,
             [required_key],
-            z3.Bool(False)
+            z3.BoolVal(False)
         )
         label_key = z3.String(f"{other_entity_type.value.name}_label_key")
         z3.RecAddDefinition(
@@ -809,7 +809,7 @@ def traits_as_z3_map(
             user_trait_key,
             [] if concrete_traits is None else list(concrete_traits.items()),
             lambda traits: z3.Or([user_trait_value == z3.StringVal(trait) for trait in traits]),
-            z3.Bool(False)
+            z3.BoolVal(False)
         )
     )
 
@@ -820,7 +820,7 @@ def traits_as_z3_map(
     z3.RecAddDefinition(
         authz_context.users[other_user_type],
         [other_user_trait_key, other_user_trait_value],
-        z3.Bool(False)
+        z3.BoolVal(False)
     )
 
 # Determines whether the given role provides the user access to the entity.
@@ -836,5 +836,7 @@ def role_allows_user_access_to_entity(
     authz_context = AuthzContext(False)
     traits_as_z3_map(authz_context, user_traits, user_type)
     labels_as_z3_map(authz_context, entity_labels, entity_type)
-    solver.add(allows(authz_context, role))
+    allows_expr = allows(authz_context, role)
+    print(allows_expr)
+    solver.add(allows_expr)
     return z3.sat == solver.check()

--- a/role_equivalence_check.py
+++ b/role_equivalence_check.py
@@ -1,13 +1,14 @@
 import argparse
 import logging
-from role_analyzer import allows
+from role_analyzer import allows, AuthzContext
 import yaml
 from z3 import Distinct, Solver, sat, unsat  # type: ignore
 
 
 def roles_are_equivalent(r1, r2) -> tuple[bool, str]:
-    r1 = allows(r1)
-    r2 = allows(r2)
+    authz_context = AuthzContext(True)
+    r1 = allows(authz_context, r1)
+    r2 = allows(authz_context, r2)
     s = Solver()
     s.add(Distinct(r1, r2))
     result = s.check()

--- a/role_query.py
+++ b/role_query.py
@@ -7,7 +7,7 @@ from role_analyzer import (
     traits_as_z3_map,
     EntityType,
     UserType,
-    AuthzContext
+    AuthzContext,
 )
 import yaml
 from z3 import Solver, sat  # type: ignore

--- a/role_query.py
+++ b/role_query.py
@@ -29,7 +29,7 @@ def node_matches_role(nodes, roles):
                 )
             else:
                 s.push()
-                s.add(allows(role))
+                s.add(allows(authz_context, role))
                 if sat == s.check():
                     print(f"Node {node_name} matches role {role_name}")
                 else:
@@ -60,7 +60,7 @@ def node_matches_user(nodes, roles, users):
             for role in user_roles:
                 s.push()
                 role_name = role["metadata"]["name"]
-                s.add(allows(role))
+                s.add(allows(authz_context, role))
                 if sat == s.check():
                     print(
                         f"User {user_name} has access to {node_name} via role {role_name}"

--- a/role_query.py
+++ b/role_query.py
@@ -7,6 +7,7 @@ from role_analyzer import (
     traits_as_z3_map,
     EntityType,
     UserType,
+    AuthzContext
 )
 import yaml
 from z3 import Solver, sat  # type: ignore
@@ -14,11 +15,12 @@ from z3 import Solver, sat  # type: ignore
 
 def node_matches_role(nodes, roles):
     s = Solver()
+    authz_context = AuthzContext(False)
     for node in nodes:
         s.push()
         node_name = node["spec"]["hostname"]
         node_labels = node["metadata"]["labels"]
-        s.add(labels_as_z3_map(node_labels, EntityType.NODE))
+        labels_as_z3_map(authz_context, node_labels, EntityType.NODE)
         for role in roles:
             role_name = role["metadata"]["name"]
             if is_role_template(role):
@@ -38,17 +40,18 @@ def node_matches_role(nodes, roles):
 
 def node_matches_user(nodes, roles, users):
     s = Solver()
+    authz_context = AuthzContext(False)
     for node in nodes:
         s.push()
         node_name = node["spec"]["hostname"]
         node_labels = node["metadata"]["labels"]
-        s.add(labels_as_z3_map(node_labels, EntityType.NODE))
+        labels_as_z3_map(authz_context, node_labels, EntityType.NODE)
 
         for user in users:
             s.push()
             user_name = user["metadata"]["name"]
             user_traits = user["spec"]["traits"]
-            s.add(traits_as_z3_map(user_traits, UserType.INTERNAL))
+            traits_as_z3_map(authz_context, user_traits, UserType.INTERNAL)
 
             user_role_names = user["spec"]["roles"]
             user_roles = filter(

--- a/role_query.py
+++ b/role_query.py
@@ -1,26 +1,20 @@
 import argparse
 import logging
 from role_analyzer import (
-    allows,
     is_role_template,
-    labels_as_z3_map,
-    traits_as_z3_map,
+    role_allows_user_access_to_entity,
     EntityType,
     UserType,
-    AuthzContext,
 )
 import yaml
 from z3 import Solver, sat  # type: ignore
 
 
 def node_matches_role(nodes, roles):
-    s = Solver()
-    authz_context = AuthzContext(False)
+    solver = Solver()
     for node in nodes:
-        s.push()
         node_name = node["spec"]["hostname"]
         node_labels = node["metadata"]["labels"]
-        labels_as_z3_map(authz_context, node_labels, EntityType.NODE)
         for role in roles:
             role_name = role["metadata"]["name"]
             if is_role_template(role):
@@ -28,40 +22,49 @@ def node_matches_role(nodes, roles):
                     f"Role {role_name} is a role template; try specifying --users to check who has access"
                 )
             else:
-                s.push()
-                s.add(allows(authz_context, role))
-                if sat == s.check():
+                solver.push()
+                allows = role_allows_user_access_to_entity(
+                    role,
+                    None,
+                    None,
+                    node_labels,
+                    EntityType.Node,
+                    solver,
+                )
+                solver.pop()
+                if allows:
                     print(f"Node {node_name} matches role {role_name}")
                 else:
                     print(f"Node {node_name} does not match role {role_name}")
-                s.pop()
-        s.pop()
 
 
 def node_matches_user(nodes, roles, users):
-    s = Solver()
-    authz_context = AuthzContext(False)
+    solver = Solver()
     for node in nodes:
-        s.push()
         node_name = node["spec"]["hostname"]
         node_labels = node["metadata"]["labels"]
-        labels_as_z3_map(authz_context, node_labels, EntityType.NODE)
 
         for user in users:
-            s.push()
             user_name = user["metadata"]["name"]
             user_traits = user["spec"]["traits"]
-            traits_as_z3_map(authz_context, user_traits, UserType.INTERNAL)
 
             user_role_names = user["spec"]["roles"]
             user_roles = filter(
                 lambda role: role["metadata"]["name"] in user_role_names, roles
             )
             for role in user_roles:
-                s.push()
                 role_name = role["metadata"]["name"]
-                s.add(allows(authz_context, role))
-                if sat == s.check():
+                solver.push()
+                allows = role_allows_user_access_to_entity(
+                    role,
+                    user_traits,
+                    UserType.INTERNAL,
+                    node_labels,
+                    EntityType.NODE,
+                    solver,
+                )
+                solver.pop()
+                if allows:
                     print(
                         f"User {user_name} has access to {node_name} via role {role_name}"
                     )
@@ -69,9 +72,6 @@ def node_matches_user(nodes, roles, users):
                     print(
                         f"User {user_name} does NOT have access to {node_name} via role {role_name}"
                     )
-                s.pop()
-            s.pop()
-        s.pop()
 
 
 def main():

--- a/tests/test_constraint_parsing.py
+++ b/tests/test_constraint_parsing.py
@@ -8,6 +8,7 @@ from role_analyzer import (
     InterpolationConstraint,
     EmailFunctionConstraint,
     RegexReplaceFunctionConstraint,
+    UserType
 )
 
 
@@ -21,18 +22,18 @@ def parse_match_any_constraint():
 
 def test_parse_template_constraint():
     values = [
-        ("internal", "key", None),
-        ("external", "key", None),
-        ("internal", "key", "inner"),
-        ("external", "key", "inner"),
+        (UserType.INTERNAL, "key", None),
+        (UserType.EXTERNAL, "key", None),
+        (UserType.INTERNAL, "key", "inner"),
+        (UserType.EXTERNAL, "key", "inner"),
     ]
 
     for value in values:
         expected = UserTraitConstraint(*value)
         unparsed = (
-            f"{{{{{expected.trait_type}.{expected.trait_key}}}}}"
+            f"{{{{{expected.trait_type.value}.{expected.trait_key}}}}}"
             if None == expected.inner_trait_key
-            else f'{{{{{expected.trait_type}.{expected.trait_key}["{expected.inner_trait_key}"]}}}}'
+            else f'{{{{{expected.trait_type.value}.{expected.trait_key}["{expected.inner_trait_key}"]}}}}'
         )
         assert requires_user_traits(unparsed), unparsed
         actual = parse_constraint(unparsed)
@@ -41,18 +42,18 @@ def test_parse_template_constraint():
 
 def test_parse_interpolation_constraint():
     values = [
-        ("prefix", "internal", "key", None, "suffix"),
-        ("prefix", "external", "key", None, "suffix"),
-        ("prefix", "internal", "key", "inner", "suffix"),
-        ("prefix", "external", "key", "inner", "suffix"),
+        ("prefix", UserType.INTERNAL, "key", None, "suffix"),
+        ("prefix", UserType.EXTERNAL, "key", None, "suffix"),
+        ("prefix", UserType.INTERNAL, "key", "inner", "suffix"),
+        ("prefix", UserType.EXTERNAL, "key", "inner", "suffix"),
     ]
 
     for value in values:
         expected = InterpolationConstraint(*value)
         unparsed = (
-            f"{expected.prefix}{{{{{expected.trait_type}.{expected.trait_key}}}}}{expected.suffix}"
+            f"{expected.prefix}{{{{{expected.trait_type.value}.{expected.trait_key}}}}}{expected.suffix}"
             if None == expected.inner_trait_key
-            else f'{expected.prefix}{{{{{expected.trait_type}.{expected.trait_key}["{expected.inner_trait_key}"]}}}}{expected.suffix}'
+            else f'{expected.prefix}{{{{{expected.trait_type.value}.{expected.trait_key}["{expected.inner_trait_key}"]}}}}{expected.suffix}'
         )
         assert requires_user_traits(unparsed), unparsed
         actual = parse_constraint(unparsed)
@@ -61,18 +62,18 @@ def test_parse_interpolation_constraint():
 
 def test_parse_email_function_constraint():
     values = [
-        ("internal", "key", None),
-        ("external", "key", None),
-        ("internal", "key", "inner"),
-        ("external", "key", "inner"),
+        (UserType.INTERNAL, "key", None),
+        (UserType.EXTERNAL, "key", None),
+        (UserType.INTERNAL, "key", "inner"),
+        (UserType.EXTERNAL, "key", "inner"),
     ]
 
     for value in values:
         expected = EmailFunctionConstraint(*value)
         unparsed = (
-            f"{{{{email.local({expected.trait_type}.{expected.trait_key})}}}}"
+            f"{{{{email.local({expected.trait_type.value}.{expected.trait_key})}}}}"
             if None == expected.inner_trait_key
-            else f'{{{{email.local({expected.trait_type}.{expected.trait_key}["{expected.inner_trait_key}"])}}}}'
+            else f'{{{{email.local({expected.trait_type.value}.{expected.trait_key}["{expected.inner_trait_key}"])}}}}'
         )
         assert requires_user_traits(unparsed), unparsed
         actual = parse_constraint(unparsed)
@@ -81,18 +82,18 @@ def test_parse_email_function_constraint():
 
 def test_parse_regexp_replace_function_constraint():
     values = [
-        ("internal", "key", None, "pattern", "replacement"),
-        ("external", "key", None, "pattern", "replacement"),
-        ("internal", "key", "inner", "pattern", "replacement"),
-        ("external", "key", "inner", "pattern", "replacement"),
+        (UserType.INTERNAL, "key", None, "pattern", "replacement"),
+        (UserType.EXTERNAL, "key", None, "pattern", "replacement"),
+        (UserType.INTERNAL, "key", "inner", "pattern", "replacement"),
+        (UserType.EXTERNAL, "key", "inner", "pattern", "replacement"),
     ]
 
     for value in values:
         expected = RegexReplaceFunctionConstraint(*value)
         unparsed = (
-            f'{{{{regexp.replace({expected.trait_type}.{expected.trait_key}, "{expected.pattern}", "{expected.replace}")}}}}'
+            f'{{{{regexp.replace({expected.trait_type.value}.{expected.trait_key}, "{expected.pattern}", "{expected.replace}")}}}}'
             if None == expected.inner_trait_key
-            else f'{{{{regexp.replace({expected.trait_type}.{expected.trait_key}["{expected.inner_trait_key}"], "{expected.pattern}", "{expected.replace}")}}}}'
+            else f'{{{{regexp.replace({expected.trait_type.value}.{expected.trait_key}["{expected.inner_trait_key}"], "{expected.pattern}", "{expected.replace}")}}}}'
         )
         assert requires_user_traits(unparsed), unparsed
         actual = parse_constraint(unparsed)

--- a/tests/test_constraint_parsing.py
+++ b/tests/test_constraint_parsing.py
@@ -8,7 +8,7 @@ from role_analyzer import (
     InterpolationConstraint,
     EmailFunctionConstraint,
     RegexReplaceFunctionConstraint,
-    UserType
+    UserType,
 )
 
 


### PR DESCRIPTION
Closes #2
Prior to these changes, assigning concrete values to entity labels or user traits was done in a roundabout way by defining constraints over some abstract function as in:
```py
app_label_keys = z3.Function("app_label_keys", z3.StringSort(), z3.BoolSort())
keys = {"foo", "bar", "baz"}
in_set = z3.And([app_label_keys(z3.StringVal(key)) for key in keys])
excluded_key = z3.String("excluded_key")
is_excluded_key = z3.And([excluded_key != z3.StringVal(key) for key in keys])
excluded = z3.Implies(is_excluded_key, z3.Not(app_label_keys(excluded_key)))
restricted_in_set = z3.And(in_set, z3.ForAll(excluded_key, excluded))
```
This is greatly simplified by defining the action of the function directly:
```py
app_label_keys = z3.RecFunction("app_label_keys", z3.StringSort(), z3.BoolSort())
keys = {"foo", "bar", "baz"}
set_membership_parameter = z3.String("set_membership_parameter")
z3.RecAddDefinition(
  app_label_keys,
  [set_membership_parameter],
  z3.Or([set_membership_parameter == z3.StringVal(key) for key in keys])
)
```
The role constraints are then checked against this defined function. Some global variables are now encapsulated in an `AuthzContext` object that must be passed down the function stack.

Mostly these changes presented an ideal opportunity to experiment with defined functions as a prelude to other work.